### PR TITLE
Migrated from using Flow with Rest to simple suspend functions.

### DIFF
--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/GoogleAuthREST.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/GoogleAuthREST.kt
@@ -1,6 +1,7 @@
 package com.openmobilehub.auth.nongms.data.login
 
 import com.openmobilehub.auth.nongms.data.login.models.AuthTokenResponse
+import retrofit2.Response
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
@@ -15,7 +16,7 @@ interface GoogleAuthREST {
         @Field("redirect_uri") redirectUri: String,
         @Field("code_verifier") codeVerifier: String,
         @Field("grant_type") grantType: String = "authorization_code",
-    ): AuthTokenResponse
+    ): Response<AuthTokenResponse>
 
     @POST("/token")
     @FormUrlEncoded
@@ -23,11 +24,11 @@ interface GoogleAuthREST {
         @Field("client_id") clientId: String,
         @Field("refresh_token") refreshToken: String,
         @Field("grant_type") grantType: String = "refresh_token"
-    ): AuthTokenResponse
+    ): Response<AuthTokenResponse>
 
     @POST("/revoke")
     @FormUrlEncoded
     suspend fun revokeToken(
         @Field("token") token: String
-    )
+    ): Response<Nothing>
 }

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/datasource/AuthDataSource.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/datasource/AuthDataSource.kt
@@ -2,7 +2,7 @@ package com.openmobilehub.auth.nongms.data.login.datasource
 
 import android.net.Uri
 import com.openmobilehub.auth.nongms.data.login.models.AuthTokenResponse
-import kotlinx.coroutines.flow.Flow
+import retrofit2.Response
 
 interface AuthDataSource {
 
@@ -14,12 +14,12 @@ interface AuthDataSource {
      * @param redirectUri -> the same redirectUri used for the custom tabs
      * @param codeVerifier -> PKCE implementation against man in the middle attacks.
      */
-    fun getToken(
+    suspend fun getToken(
         clientId: String,
         authCode: String,
         redirectUri: String,
         codeVerifier: String
-    ) : Flow<AuthTokenResponse>
+    ): Response<AuthTokenResponse>
 
     /**
      * Builds the login URL for the Custom Tabs screen. If the login is successful, an auth code
@@ -59,9 +59,9 @@ interface AuthDataSource {
      *
      * @param clientId -> clientId from the auth console
      *
-     * @return a [Flow] with the [AuthTokenResponse]
+     * @return a [Response] with the [AuthTokenResponse]
      */
-    fun refreshAccessToken(clientId: String): Flow<AuthTokenResponse>
+    suspend fun refreshAccessToken(clientId: String): Response<AuthTokenResponse>
 
     /**
      * Indicates the auth provider that the token should be revoked. When logging out, this step is
@@ -69,7 +69,7 @@ interface AuthDataSource {
      *
      * @param token -> token to revoke.
      */
-    fun revokeToken(token: String): Flow<Unit>
+    suspend fun revokeToken(token: String): Response<Nothing>
 
     /**
      * Clears all local data of the user, including any stored tokens.

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/datasource/GoogleAuthDataSource.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/data/login/datasource/GoogleAuthDataSource.kt
@@ -7,27 +7,25 @@ import androidx.core.net.toUri
 import com.openmobilehub.auth.nongms.data.login.GoogleAuthREST
 import com.openmobilehub.auth.nongms.data.login.models.AuthTokenResponse
 import com.openmobilehub.auth.nongms.utils.Constants
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import retrofit2.Response
 
 class GoogleAuthDataSource(
     private val authService: GoogleAuthREST,
     private val sharedPreferences: SharedPreferences
 ) : AuthDataSource {
 
-    override fun getToken(
+    override suspend fun getToken(
         clientId: String,
         authCode: String,
         redirectUri: String,
         codeVerifier: String
-    ): Flow<AuthTokenResponse> = flow {
-        val authTokenResponse: AuthTokenResponse = authService.getToken(
+    ): Response<AuthTokenResponse> {
+        return authService.getToken(
             clientId = clientId,
             code = authCode,
             redirectUri = redirectUri,
             codeVerifier = codeVerifier
         )
-        emit(authTokenResponse)
     }
 
     /**
@@ -70,13 +68,13 @@ class GoogleAuthDataSource(
         return sharedPreferences.getString(AuthDataSource.REFRESH_TOKEN, null)
     }
 
-    override fun refreshAccessToken(clientId: String): Flow<AuthTokenResponse> = flow {
+    override suspend fun refreshAccessToken(clientId: String): Response<AuthTokenResponse> {
         val refreshToken = checkNotNull(getRefreshToken())
-        emit(authService.refreshToken(clientId, refreshToken))
+        return (authService.refreshToken(clientId, refreshToken))
     }
 
-    override fun revokeToken(token: String): Flow<Unit> = flow {
-        emit(authService.revokeToken(token))
+    override suspend fun revokeToken(token: String): Response<Nothing> {
+        return (authService.revokeToken(token))
     }
 
     override fun clearData() {

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/auth/AuthRepository.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/auth/AuthRepository.kt
@@ -1,7 +1,7 @@
 package com.openmobilehub.auth.nongms.domain.auth
 
+import com.openmobilehub.auth.nongms.domain.models.ApiResult
 import com.openmobilehub.auth.nongms.domain.models.OAuthTokens
-import kotlinx.coroutines.flow.Flow
 
 internal interface AuthRepository {
 
@@ -13,12 +13,12 @@ internal interface AuthRepository {
      * @param redirectUri -> the same redirect URI from the login screen
      * @param codeVerifier -> code verifier of the PKCE protocol
      */
-    fun requestTokens(
+    suspend fun requestTokens(
         clientId: String,
         authCode: String,
         redirectUri: String,
         codeVerifier: String
-    ): Flow<OAuthTokens>
+    ): ApiResult<OAuthTokens>
 
     /**
      * Builds the login URL to use in the custom tabs implementation. This will show the user the
@@ -48,14 +48,14 @@ internal interface AuthRepository {
      *
      * @param clientId -> clientId from the auth console
      *
-     * @return a [Flow] with the token inside.
+     * @return a [ApiResult] with the token inside.
      */
-    fun refreshAccessToken(clientId: String): Flow<String>
+    suspend fun refreshAccessToken(clientId: String): ApiResult<String>
 
     /**
      * Revokes the access token of the user from the auth provider.
      */
-    fun revokeToken(): Flow<Unit>
+    suspend fun revokeToken(): ApiResult<Unit>
 
     /**
      * Clears all local data of the user, including stored tokens.

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/auth/AuthUseCase.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/auth/AuthUseCase.kt
@@ -1,11 +1,9 @@
 package com.openmobilehub.auth.nongms.domain.auth
 
+import com.openmobilehub.auth.nongms.domain.models.ApiResult
 import com.openmobilehub.auth.nongms.domain.models.OAuthTokens
 import com.openmobilehub.auth.nongms.domain.utils.Pkce
 import com.openmobilehub.auth.nongms.domain.utils.PkceImpl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
 
 internal class AuthUseCase(
     private val authRepository: AuthRepository,
@@ -25,7 +23,7 @@ internal class AuthUseCase(
         )
     }
 
-    fun requestTokens(authCode: String, packageName: String): Flow<OAuthTokens> {
+    suspend fun requestTokens(authCode: String, packageName: String): ApiResult<OAuthTokens> {
         return authRepository.requestTokens(
             clientId = _clientId,
             authCode = authCode,
@@ -34,11 +32,8 @@ internal class AuthUseCase(
         )
     }
 
-    fun blockingRefreshToken(): Flow<String?> {
-        return authRepository
-            .refreshAccessToken(_clientId)
-            .map { token -> token.ifEmpty { null } }
-            .catch { emit(null) }
+    suspend fun blockingRefreshToken(): ApiResult<String> {
+        return authRepository.refreshAccessToken(_clientId)
     }
 
     fun getAccessToken(): String? = authRepository.getAccessToken()

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/models/ApiResult.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/models/ApiResult.kt
@@ -1,0 +1,8 @@
+package com.openmobilehub.auth.nongms.domain.models
+
+sealed class ApiResult<out T> {
+
+    data class Success<out R>(val data: R) : ApiResult<R>()
+
+    data class Error(val exception: String) : ApiResult<Nothing>()
+}

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/models/DataResponse.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/domain/models/DataResponse.kt
@@ -1,9 +1,0 @@
-package com.openmobilehub.auth.nongms.domain.models
-
-class DataResponse<T>(
-    val response: T? = null,
-    val errorDetail: String? = null
-) {
-    val isSuccessful: Boolean
-        get() = response != null
-}

--- a/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/presentation/OmhCredentialsImpl.kt
+++ b/auth-api-non-gms/src/main/java/com/openmobilehub/auth/nongms/presentation/OmhCredentialsImpl.kt
@@ -1,9 +1,9 @@
 package com.openmobilehub.auth.nongms.presentation
 
-import com.openmobilehub.auth.nongms.domain.auth.AuthUseCase
-import com.openmobilehub.auth.nongms.utils.ThreadUtils
 import com.openmobilehub.auth.api.OmhCredentials
-import kotlinx.coroutines.flow.first
+import com.openmobilehub.auth.nongms.domain.auth.AuthUseCase
+import com.openmobilehub.auth.nongms.domain.models.ApiResult
+import com.openmobilehub.auth.nongms.utils.ThreadUtils
 import kotlinx.coroutines.runBlocking
 
 internal class OmhCredentialsImpl(
@@ -18,7 +18,10 @@ internal class OmhCredentialsImpl(
     override fun blockingRefreshToken(): String? {
         ThreadUtils.checkForMainThread()
         return runBlocking {
-            authUseCase.blockingRefreshToken().first()
+            when (val apiResult = authUseCase.blockingRefreshToken()) {
+                is ApiResult.Error -> null
+                is ApiResult.Success -> apiResult.data
+            }
         }
     }
 


### PR DESCRIPTION
After some time with working on the code, the Flow library seemed like an overkill for the REST calls, because the design is done around a constant stream of data, unlike the Single or Completable from Rx. 

After some digging I found an approach that was more fitting to use a sealed class to encompass API responses and extend it into an Error and Success classes for handling both cases. This way we can use Kotlin's when switch to handle both cases as if it were a callback if needed. This is only for internal calls in the Auth module like getTokens() or refreshToken(). 

Improvements can be done for the Error use case, but they'll be probably be handled in the Error Handled chapter of the library creation.