### PR TITLE
Renamed unit tests according to standard.

### DIFF
--- a/auth-api-non-gms/src/test/java/com/omh/android/auth/nongms/AuthUseCaseTest.kt
+++ b/auth-api-non-gms/src/test/java/com/omh/android/auth/nongms/AuthUseCaseTest.kt
@@ -27,7 +27,7 @@ internal class AuthUseCaseTest {
     private val authUseCase = AuthUseCase(authRepository, pkce)
 
     @Test
-    fun `when given scope and packageName a correct Uri is returned`() {
+    fun `given a scope and package name when requesting login URl a correct string is returned`() {
         val scope = "scope"
         val packageName = "com.package.name"
         val expectedRedirect: String = AuthUseCase.REDIRECT_FORMAT.format(packageName)
@@ -51,29 +51,31 @@ internal class AuthUseCaseTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `when given auth code and package name an AuthTokenResponse is returned`() = runTest {
-        val authCode = "auth code"
-        val packageName = "com.package.name"
-        val mockedResponse: OAuthTokens = mockk()
-        val expectedResult = ApiResult.Success(mockedResponse)
+    fun `given an auth code and package name when tokens are requested then they are returned`() {
+        runTest {
+            val authCode = "auth code"
+            val packageName = "com.package.name"
+            val mockedResponse: OAuthTokens = mockk()
+            val expectedResult = ApiResult.Success(mockedResponse)
         val clientId = "client ID"
 
-        coEvery {
-            authRepository.requestTokens(
-                clientId = any(),
-                authCode = any(),
-                redirectUri = any(),
-                codeVerifier = any(),
-            )
-        } returns expectedResult
+            coEvery {
+                authRepository.requestTokens(
+                    clientId = any(),
+                    authCode = any(),
+                    redirectUri = any(),
+                    codeVerifier = any(),
+                )
+            } returns expectedResult
 
-        val result = authUseCase.requestTokens(authCode, packageName, clientId)
+            val result = authUseCase.requestTokens(authCode, packageName, clientId)
 
-        assertEquals(expectedResult, result)
+            assertEquals(expectedResult, result)
+        }
     }
 
     @Test
-    fun `when the access token is requested then the token is returned`() {
+    fun `given that an access token was stored when it's requested then it's returned`() {
         val expectedToken = "accesstoken"
         every { authRepository.getAccessToken() } returns expectedToken
 
@@ -83,7 +85,7 @@ internal class AuthUseCaseTest {
     }
 
     @Test
-    fun `when the access token is requested but no token is stored then null is returned`() {
+    fun `given that an access token wasn't stored when it's requested then null returned`() {
         val expectedToken = null
         every { authRepository.getAccessToken() } returns expectedToken
 
@@ -94,7 +96,7 @@ internal class AuthUseCaseTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `when a token refresh is requested then a new token is returned`() = runTest {
+    fun `when a refresh is requested then a new token is returned`() = runTest {
         val expectedToken = "newtoken"
         val expectedResult = ApiResult.Success(expectedToken)
         val clientId = "client ID"

--- a/auth-api-non-gms/src/test/java/com/omh/android/auth/nongms/ProfileUseCaseTest.kt
+++ b/auth-api-non-gms/src/test/java/com/omh/android/auth/nongms/ProfileUseCaseTest.kt
@@ -21,7 +21,7 @@ internal class ProfileUseCaseTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `when idToken and clientId are provided the token is handled`() = runTest {
+    fun `given idToken and clientId then the ID token is resolved`() = runTest {
         val idToken = "idToken"
         val clientId = "clientId"
         coEvery { userRepository.handleIdToken(any(), any()) } returns Unit
@@ -33,7 +33,7 @@ internal class ProfileUseCaseTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test(expected = OmhAuthException.UnrecoverableLoginException::class)
-    fun `when idToken or clientId are empty the token is not handled`() = runTest {
+    fun `given idToken and clientId when they are empty then an exception is thrown`() = runTest {
         val idToken = " "
         val clientId = " "
         coEvery { userRepository.handleIdToken(any(), any()) } returns Unit
@@ -44,7 +44,7 @@ internal class ProfileUseCaseTest {
     }
 
     @Test
-    fun `when no profile data is available a null is returned`() {
+    fun `when no profile data is available then null is returned`() {
         every { userRepository.getProfileData() } returns null
 
         val result = useCase.getProfileData()
@@ -53,7 +53,7 @@ internal class ProfileUseCaseTest {
     }
 
     @Test
-    fun `when profile data is available an object is returned`() {
+    fun `when profile data is available then an OmhUserProfile is returned`() {
         val profileData: OmhUserProfile = mockk()
         every { userRepository.getProfileData() } returns profileData
 


### PR DESCRIPTION
Reformatted the unit test names according to @bardur-encora comment here: https://github.com/openmobilehub/omh-maps/pull/3#discussion_r1140515153

> Is there standard for test naming in this project
> 
> ex `` fun `Given [state], When [condition], Then [expected result]`() ``
> 
> If not, then please define one and ensure that they are used in the project!

