### PR TITLE
Refactored the provider to receive reflection paths from outside.

### DIFF
--- a/auth-api/build.gradle.kts
+++ b/auth-api/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
     implementation(Libs.material)
     implementation(Libs.reflection)
 
+    implementation(Libs.googlePlayBase) // Provides a way to check for GMS availability
+
     // Test dependencies
     testImplementation(Libs.junit)
     androidTestImplementation(Libs.androidJunit)

--- a/auth-api/src/main/java/com/omh/android/auth/api/OmhAuthProvider.kt
+++ b/auth-api/src/main/java/com/omh/android/auth/api/OmhAuthProvider.kt
@@ -1,15 +1,22 @@
 package com.omh.android.auth.api
 
 import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.omh.android.auth.api.models.OmhAuthException
+import com.omh.android.auth.api.models.OmhAuthStatusCodes
 import kotlin.reflect.KClass
 
 /**
  * Object that providers the correct implementation of the client for GMS or non GMS builds.
  */
-object OmhAuthProvider {
+class OmhAuthProvider private constructor(
+    private val gmsPath: String?,
+    private val nonGmsPath: String?
+) {
 
-    private const val NGMS_ADDRESS = "com.omh.android.auth.nongms.presentation.OmhAuthFactoryImpl"
-    private const val GMS_ADDRESS = "com.omh.android.auth.gms.OmhAuthFactoryImpl"
+    private val isSingleBuild = gmsPath != null && nonGmsPath != null
+
 
     /**
      * Provides an auth client interface to interact with the OMH Auth library. This uses reflection
@@ -20,22 +27,78 @@ object OmhAuthProvider {
      * @param scopes -> your oauth scopes in a collection. Do take into account that non GMS devices
      * won't be able to request more scopes after the first authorization.
      * @param clientId -> your client ID for the Android Application.
+     * @param ownReflectionPath -> provide your own reflection path in case you are implementing
+     * your own OMH module.
      *
      * @return an [OmhAuthClient] to interact with the Auth module.
+     * @throws [OmhAuthException.ApiException] when reflection fails for any of the implementations
+     * of the [OmhAuthFactory]. If this happens, look if you have configured correctly the gradle
+     * plugin or if your obfuscation method hasn't tampered with the library files.
      */
-    @SuppressWarnings("SwallowedException")
+    @Throws(OmhAuthException.ApiException::class)
     fun provideAuthClient(
         context: Context,
         scopes: Collection<String>,
-        clientId: String
+        clientId: String,
     ): OmhAuthClient {
-        val omhAuthFactory = try {
-            val clazz: KClass<out Any> = Class.forName(GMS_ADDRESS).kotlin
-            clazz.objectInstance as OmhAuthFactory
-        } catch (e: ClassNotFoundException) {
-            val clazz: KClass<out Any> = Class.forName(NGMS_ADDRESS).kotlin
-            clazz.objectInstance as OmhAuthFactory
+        val omhAuthFactory: OmhAuthFactory = try {
+            getOmhAuthFactory(context)
+        } catch (exception: ClassNotFoundException) {
+            throw OmhAuthException.ApiException(
+                statusCode = OmhAuthStatusCodes.DEVELOPER_ERROR,
+                cause = exception
+            )
         }
         return omhAuthFactory.getAuthClient(context, scopes, clientId)
+    }
+
+    @Throws(ClassNotFoundException::class)
+    private fun getOmhAuthFactory(context: Context) = when {
+        isSingleBuild -> reflectSingleBuild(context)
+        gmsPath != null -> getFactoryImplementation(gmsPath)
+        nonGmsPath != null -> getFactoryImplementation(nonGmsPath)
+        else -> throw OmhAuthException.ApiException(
+            statusCode = OmhAuthStatusCodes.DEVELOPER_ERROR,
+            cause = IllegalStateException("NO PATHS PROVIDED")
+        )
+    }
+
+    @Throws(ClassNotFoundException::class)
+    private fun reflectSingleBuild(
+        context: Context,
+    ): OmhAuthFactory {
+        val googleApiAvailability = GoogleApiAvailability.getInstance()
+        return when (googleApiAvailability.isGooglePlayServicesAvailable(context)) {
+            ConnectionResult.SUCCESS -> getFactoryImplementation(gmsPath!!)
+            else -> getFactoryImplementation(nonGmsPath!!)
+        }
+    }
+
+    @Throws(ClassNotFoundException::class)
+    private fun getFactoryImplementation(path: String): OmhAuthFactory {
+        val clazz: KClass<out Any> = Class.forName(path).kotlin
+        return clazz.objectInstance as OmhAuthFactory
+    }
+
+    class Builder {
+        private var gmsPath: String? = null
+        private var nonGmsPath: String? = null
+
+        fun addGmsPath(path: String?): Builder {
+            gmsPath = path
+            return this
+        }
+
+        fun addNonGmsPath(path: String?): Builder {
+            nonGmsPath = path
+            return this
+        }
+
+        fun build(): OmhAuthProvider = OmhAuthProvider(gmsPath, nonGmsPath)
+    }
+
+    companion object {
+        const val NGMS_ADDRESS = "com.omh.android.auth.nongms.presentation.OmhAuthFactoryImpl"
+        const val GMS_ADDRESS = "com.omh.android.auth.gms.OmhAuthFactoryImpl"
     }
 }

--- a/auth-api/src/main/java/com/omh/android/auth/api/models/OmhAuthException.kt
+++ b/auth-api/src/main/java/com/omh/android/auth/api/models/OmhAuthException.kt
@@ -19,4 +19,7 @@ sealed class OmhAuthException(val statusCode: Int) : Exception() {
         statusCode: Int,
         override val cause: Throwable? = null
     ) : OmhAuthException(statusCode)
+
+    override val message: String?
+        get() = OmhAuthStatusCodes.getStatusCodeString(statusCode)
 }

--- a/auth-sample/build.gradle.kts
+++ b/auth-sample/build.gradle.kts
@@ -35,6 +35,9 @@ android {
         create("gms") {
             dimension = "google_services"
         }
+        create("singleBuild") {
+            dimension = "google_services"
+        }
     }
 
     viewBinding {
@@ -51,9 +54,14 @@ android {
 
 val gmsImplementation by configurations
 val ngmsImplementation by configurations
+val singleBuildImplementation by configurations
 dependencies {
     ngmsImplementation(project(":auth-api-non-gms"))
+
     gmsImplementation(project(":auth-api-gms"))
+
+    singleBuildImplementation(project(":auth-api-non-gms"))
+    singleBuildImplementation(project(":auth-api-gms"))
 
     implementation(Libs.googleApiClientAndroid)
 

--- a/auth-sample/src/gms/kotlin/di/SingletonModule.kt
+++ b/auth-sample/src/gms/kotlin/di/SingletonModule.kt
@@ -1,0 +1,27 @@
+package di
+
+import android.content.Context
+import com.omh.android.auth.api.OmhAuthClient
+import com.omh.android.auth.api.OmhAuthProvider
+import com.omh.android.auth.sample.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SingletonModule {
+    @Provides
+    fun providesOmhAuthClient(@ApplicationContext context: Context): OmhAuthClient {
+        val omhAuthProvider = OmhAuthProvider.Builder()
+            .addGmsPath(OmhAuthProvider.GMS_ADDRESS)
+            .build()
+        return omhAuthProvider.provideAuthClient(
+            scopes = listOf("openid", "email", "profile"),
+            clientId = BuildConfig.CLIENT_ID,
+            context = context
+        )
+    }
+}

--- a/auth-sample/src/ngms/kotlin/di/SingletonModule.kt
+++ b/auth-sample/src/ngms/kotlin/di/SingletonModule.kt
@@ -1,4 +1,4 @@
-package com.omh.android.auth.sample.di
+package di
 
 import android.content.Context
 import com.omh.android.auth.api.OmhAuthClient
@@ -15,7 +15,10 @@ import dagger.hilt.components.SingletonComponent
 object SingletonModule {
     @Provides
     fun providesOmhAuthClient(@ApplicationContext context: Context): OmhAuthClient {
-        return OmhAuthProvider.provideAuthClient(
+        val omhAuthProvider = OmhAuthProvider.Builder()
+            .addNonGmsPath(OmhAuthProvider.NGMS_ADDRESS)
+            .build()
+        return omhAuthProvider.provideAuthClient(
             scopes = listOf("openid", "email", "profile"),
             clientId = BuildConfig.CLIENT_ID,
             context = context

--- a/auth-sample/src/singleBuild/kotlin/di/SingletonModule.kt
+++ b/auth-sample/src/singleBuild/kotlin/di/SingletonModule.kt
@@ -1,0 +1,28 @@
+package di
+
+import android.content.Context
+import com.omh.android.auth.api.OmhAuthClient
+import com.omh.android.auth.api.OmhAuthProvider
+import com.omh.android.auth.sample.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SingletonModule {
+    @Provides
+    fun providesOmhAuthClient(@ApplicationContext context: Context): OmhAuthClient {
+        val omhAuthProvider = OmhAuthProvider.Builder()
+            .addNonGmsPath(OmhAuthProvider.NGMS_ADDRESS)
+            .addGmsPath(OmhAuthProvider.GMS_ADDRESS)
+            .build()
+        return omhAuthProvider.provideAuthClient(
+            scopes = listOf("openid", "email", "profile"),
+            clientId = BuildConfig.CLIENT_ID,
+            context = context
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -39,7 +39,8 @@ object Libs {
     val material by lazy { "com.google.android.material:material:${Versions.material}" }
 
     // Google Sign In
-    val googleSignIn by lazy { "com.google.android.gms:play-services-auth:${Versions.googlesignin}" }
+    val googleSignIn by lazy { "com.google.android.gms:play-services-auth:${Versions.googleSignIn}" }
+    val googlePlayBase by lazy { "com.google.android.gms:play-services-base:${Versions.googlePlayBase}" }
 
     // Testing
     val junit by lazy { "junit:junit:${Versions.junit}" }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,7 +27,8 @@ object Versions {
     const val material = "1.8.0"
 
     // Google Sign In
-    const val googlesignin = "20.4.1"
+    const val googleSignIn = "20.4.1"
+    const val googlePlayBase = "18.2.0"
 
     // Testing
     const val junit = "4.13.2"


### PR DESCRIPTION
Reworked the provider implementation for the API layer to handle only the reflection of the objects. The paths for the reflection should be provided from outside.

This also adds source sets to the sample app to handle each configuration (GMS, non GMS and single build) and their respective paths of reflection.