### PR TITLE
Fixed the crash when the Google Account is removed from the phone.

### DIFF
--- a/auth-api-gms/src/main/java/com/omh/android/auth/gms/util/Mappers.kt
+++ b/auth-api-gms/src/main/java/com/omh/android/auth/gms/util/Mappers.kt
@@ -3,6 +3,7 @@ package com.omh.android.auth.gms.util
 import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.internal.service.Common
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.omh.android.auth.api.models.OmhAuthException
@@ -24,6 +25,8 @@ internal fun Exception.toOmhApiException(): OmhAuthException.ApiException {
     val apiException: ApiException? = this as? ApiException
     val statusCode: Int = when (apiException?.statusCode) {
         CommonStatusCodes.API_NOT_CONNECTED -> OmhAuthStatusCodes.GMS_UNAVAILABLE
+        CommonStatusCodes.SIGN_IN_REQUIRED -> OmhAuthStatusCodes.SIGN_IN_REQUIRED
+        CommonStatusCodes.NETWORK_ERROR -> OmhAuthStatusCodes.NETWORK_ERROR
         else -> OmhAuthStatusCodes.INTERNAL_ERROR
     }
     return OmhAuthException.ApiException(

--- a/auth-api/src/main/java/com/omh/android/auth/api/models/OmhAuthStatusCodes.kt
+++ b/auth-api/src/main/java/com/omh/android/auth/api/models/OmhAuthStatusCodes.kt
@@ -11,6 +11,7 @@ object OmhAuthStatusCodes {
     const val DEFAULT_ERROR = -1
     const val GMS_UNAVAILABLE = 7
     const val HTTPS_ERROR = 8
+    const val SIGN_IN_REQUIRED = 9
 
     @JvmStatic
     fun getStatusCodeString(code: Int): String {
@@ -24,6 +25,7 @@ object OmhAuthStatusCodes {
             DEFAULT_ERROR -> "An error has occurred."
             GMS_UNAVAILABLE -> "GMS not available."
             HTTPS_ERROR -> "An HTTPS error has occurred."
+            SIGN_IN_REQUIRED -> "Sign in required."
             else -> "Unknown status code: $code"
         }
     }

--- a/auth-sample/build.gradle.kts
+++ b/auth-sample/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(Libs.androidAppCompat)
     implementation(Libs.material)
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("com.google.android.gms:play-services-auth-base:18.0.8")
 
     // Hilt
     implementation("com.google.dagger:hilt-android:2.44")


### PR DESCRIPTION
 Wrapped the token request exception for the `GoogleAccountCredential` in a try catch to avoid the crash and automatically logout the user. Also added `OmhStatusCodes` to represent the `CommonStatusCodes.SIGN_IN_REQUIRED`